### PR TITLE
Remove undefined variable

### DIFF
--- a/admin/includes/upload_beer.php
+++ b/admin/includes/upload_beer.php
@@ -136,7 +136,6 @@ else
               $beerFermManager->Save($beerFerm);			  
             }
 	
-            $hops[] = $hop->NAME;
             foreach ($recipe->HOPS->HOP as $hop)
             {
               $dbHop = $hopManager->GetByName($hop->NAME);


### PR DESCRIPTION
Trying to upload a beer from an xml file generates the error below. It looks like there's a defunct line of code in the upload script. This patch removes it.
```
[Sat Jun 20 10:48:05.015338 2020] [php7:notice] [pid 31058] [client 10.0.1.10:52531] PHP Notice:  Undefined variable: hop in /var/www/html/admin/includes/upload_beer.php on line 139, referer: http://10.0.1.31/admin/beer_form_xml.php
[Sat Jun 20 10:48:05.015529 2020] [php7:notice] [pid 31058] [client 10.0.1.10:52531] PHP Notice:  Trying to get property 'NAME' of non-object in /var/www/html/admin/includes/upload_beer.php on line 139, referer: http://10.0.1.31/admin/beer_form_xml.php
```