### PR TITLE
Fix query for multiple temperature probes

### DIFF
--- a/admin/includes/managers/tempProbe_manager.php
+++ b/admin/includes/managers/tempProbe_manager.php
@@ -25,18 +25,7 @@ class TempProbeManager extends Manager{
         return $this->executeNonObjectQueryWithArrayResults($sql)[0];
 	}
 	function get_lastTemp(){
-	    $ret = array();
-	    $probes = $this->GetAllActive();
-	    foreach( $probes as $probe)
-	    {
-	       $sql="SELECT temp, tempUnit, probe, takenDate FROM tempLog WHERE probe = '".$probe->get_name()."' ORDER BY takenDate DESC LIMIT 1";
-	       $tlog = $this->executeNonObjectQueryWithArrayResults($sql);
-           if( count($tlog) > 0)
-           {
-               if($probe->get_notes() !== '') $tlog[0]["probe"] = $probe->get_notes();
-               array_push($ret, $tlog[0]);
-           }
-	    }
-        return $ret;
+        $sql="SELECT temp, tempUnit, COALESCE(NULLIF(p.notes,''), tl.probe) AS probe, takenDate AS takenDate FROM tempProbes p LEFT JOIN tempLog tl ON (tl.probe = p.name AND tl.takenDate = (SELECT MAX(takenDate) FROM tempLog tl2 WHERE tl2.probe = tl.probe))WHERE p.active = 1 ORDER BY tl.probe ASC";
+        return $this->executeNonObjectQueryWithArrayResults($sql);
 	}
 }

--- a/admin/includes/managers/tempProbe_manager.php
+++ b/admin/includes/managers/tempProbe_manager.php
@@ -25,7 +25,7 @@ class TempProbeManager extends Manager{
         return $this->executeNonObjectQueryWithArrayResults($sql)[0];
 	}
 	function get_lastTemp(){
-        $sql="SELECT tp.temp, tp.tempUnit, tn.notes as probe, tp.takenDate from tempProbes tn LEFT OUTER JOIN (SELECT tt.temp, tt.tempUnit, tt.probe, tt.takenDate FROM tempLog tt INNER JOIN (SELECT probe, MAX(takenDate) AS MaxDateTime     FROM tempLog   GROUP BY probe) groupedtt  ON tt.probe = groupedtt.probe  AND tt.takenDate = groupedtt.MaxDateTime) tp ON tp.probe = tn.name;";
+        $sql="SELECT tp.temp, tp.tempUnit, tn.notes as probe, tp.takenDate from tempProbes tn LEFT OUTER JOIN (SELECT tt.temp, tt.tempUnit, tt.probe, tt.takenDate FROM tempLog tt INNER JOIN (SELECT probe, MAX(takenDate) AS MaxDateTime FROM tempLog GROUP BY probe) groupedtt ON tt.probe = groupedtt.probe AND tt.takenDate = groupedtt.MaxDateTime) tp ON tp.probe = tn.name WHERE tn.notes IS NOT NULL;";
         return $this->executeNonObjectQueryWithArrayResults($sql);
 	}
 }

--- a/admin/includes/managers/tempProbe_manager.php
+++ b/admin/includes/managers/tempProbe_manager.php
@@ -25,7 +25,7 @@ class TempProbeManager extends Manager{
         return $this->executeNonObjectQueryWithArrayResults($sql)[0];
 	}
 	function get_lastTemp(){
-        $sql="SELECT temp, tempUnit, COALESCE(NULLIF(p.notes,''), tl.probe) AS probe, takenDate AS takenDate FROM tempProbes p LEFT JOIN tempLog tl ON (tl.probe = p.name AND tl.takenDate = (SELECT MAX(takenDate) FROM tempLog tl2 WHERE tl2.probe = tl.probe))WHERE p.active = 1 ORDER BY tl.probe ASC";
+        $sql="SELECT tp.temp, tp.tempUnit, tn.notes as probe, tp.takenDate from tempProbes tn LEFT OUTER JOIN (SELECT tt.temp, tt.tempUnit, tt.probe, tt.takenDate FROM tempLog tt INNER JOIN (SELECT probe, MAX(takenDate) AS MaxDateTime     FROM tempLog   GROUP BY probe) groupedtt  ON tt.probe = groupedtt.probe  AND tt.takenDate = groupedtt.MaxDateTime) tp ON tp.probe = tn.name;";
         return $this->executeNonObjectQueryWithArrayResults($sql);
 	}
 }


### PR DESCRIPTION
Revert the temporary fix and replace it with a faster query.

Old query:
```
MariaDB [raspberrypints]> SELECT temp, tempUnit, COALESCE(NULLIF(p.notes,''), tl.probe) AS probe, takenDate AS takenDate FROM tempProbes p LEFT JOIN tempLog tl ON (tl.probe = p.name AND tl.takenDate = (SELECT MAX(takenDate) FROM tempLog tl2 WHERE tl2.probe = tl.probe))WHERE p.active = 1 ORDER BY tl.probe ASC;
+-------+----------+-----------------+---------------------+
| temp  | tempUnit | probe           | takenDate           |
+-------+----------+-----------------+---------------------+
| 23.00 | C        | Probe 1         | 2020-07-14 10:05:15 |
| 22.20 | C        | 28-3c01b556e543 | 2020-07-14 10:05:16 |
+-------+----------+-----------------+---------------------+
2 rows in set (2 min 42.465 sec)
```

New query:
```
MariaDB [raspberrypints]> SELECT tp.temp, tp.tempUnit, tn.notes as probe, tp.takenDate from tempProbes tn LEFT OUTER JOIN (SELECT tt.temp, tt.tempUnit, tt.probe, tt.takenDate FROM tempLog tt INNER JOIN (SELECT probe, MAX(takenDate) AS MaxDateTime     FROM tempLog   GROUP BY probe) groupedtt  ON tt.probe = groupedtt.probe  AND tt.takenDate = groupedtt.MaxDateTime) tp ON tp.probe = tn.name;
+-------+----------+---------+---------------------+
| temp  | tempUnit | probe   | takenDate           |
+-------+----------+---------+---------------------+
| 23.00 | C        | Probe 1 | 2020-07-14 10:08:00 |
| 22.20 | C        | NULL    | 2020-07-14 10:08:01 |
+-------+----------+---------+---------------------+
2 rows in set (0.252 sec)
```